### PR TITLE
scoutfs: set default slot to -1 to identify non-quorum nodes

### DIFF
--- a/scoutfs.go
+++ b/scoutfs.go
@@ -693,7 +693,7 @@ func GetQuorumInfo(path string) (QuorumInfo, error) {
 	}
 	defer sfs.Close()
 
-	qi := QuorumInfo{}
+	qi := QuorumInfo{Slot: -1}
 	scanner := bufio.NewScanner(sfs)
 	for scanner.Scan() {
 		fields := strings.Fields(scanner.Text())


### PR DESCRIPTION
Set default value of QuorumInfo returned to have slot = -1.  This allows us to identify non-quorum nodes, since the field "quorum_slot_nr" may not be present in sysfs report